### PR TITLE
Corrected spacing after "=" sign in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To use the default template, put this in your config file
 ```
 au BufEnter * :OneStatus
 set noshowmode noruler
-set laststatus = 0
+set laststatus =0
 ```
 You can of course not use `BufEnter` and use `WinEnter` or some other events but I found it sufficient for my use case.
 


### PR DESCRIPTION
In readme.md 
`set laststatus = 0` should be `set laststatus =0`
It doesn't work with the space in between `=` and `0`